### PR TITLE
fix: 完善 Vue.extend() 构造函数打印方式，修复 wrapperRefDom bug

### DIFF
--- a/print.js
+++ b/print.js
@@ -80,14 +80,18 @@ Print.prototype = {
     }
     // 包裹要打印的元素
     // fix: https://github.com/xyl66/vuePlugs_printjs/issues/36
-    return this.wrapperRefDom(this.dom).outerHTML;
+    let outerHTML = this.wrapperRefDom(this.dom).outerHTML
+    return outerHTML;
   },
   // 向父级元素循环，包裹当前需要打印的元素
   // 防止根级别开头的 css 选择器不生效
   wrapperRefDom: function (refDom) {
     let prevDom = null
     let currDom = refDom
-    while (currDom && currDom.tagName.toLowerCase() !== 'body') {
+    // 判断当前元素是否在 body 中，不在文档中则直接返回该节点
+    if (!this.isInBody(currDom)) return currDom
+
+    while (currDom) {
       if (prevDom) {
         let element = currDom.cloneNode(false)
         element.appendChild(prevDom)
@@ -99,7 +103,7 @@ Print.prototype = {
       currDom = currDom.parentElement
     }
 
-    return currDom.tagName.toLowerCase() === 'body' ? currDom : prevDom
+    return prevDom
   },
 
   writeIframe: function (content) {
@@ -138,6 +142,10 @@ Print.prototype = {
     } catch (err) {
       console.log('err', err);
     }
+  },
+  // 检查一个元素是否是 body 元素的后代元素且非 body 元素本身
+  isInBody: function (node) {
+    return (node === document.body) ? false : document.body.contains(node);
   },
   isDOM: (typeof HTMLElement === 'object') ?
     function (obj) {


### PR DESCRIPTION
### 新增 `Vue.extend()` 构造函数方式打印

```vue
// Template.vue

<template>
    <div>
        <h2>{{title}}</h2>
    </div>
</template>

<script>
export default {
    name: 'Template',
}
</script>
```


```js
 // Template 为 *.vue 单文件组件，如上所示

 let Temp = Vue.extend(Template)
 let childVM = new Temp({
   data () {
        return {
            title: '这是个标题'
      }
   },
 }).$mount(document.createElement('div'))

this.$print(childVM)
```